### PR TITLE
Gitのテキスト教材を表示するように修正し，G管理者画面から選択可能に修正

### DIFF
--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register Text do
+  PROGRAMMING = ["Basic", "Git", "Ruby", "Ruby on Rails"].freeze
   # ドロップダウンメニューの親成分を決定
   menu parent: "テキスト教材"
   permit_params :genre, :title, :contents, :image, :description
@@ -30,7 +31,7 @@ ActiveAdmin.register Text do
 
   form do |_f|
     inputs  do
-      input :genre, as: :select, collection: ["Basic", "Ruby", "Ruby on Rails"]
+      input :genre, as: :select, collection: PROGRAMMING
       input :title, as: :string
       input :contents
       input :image, as: :file

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -19,7 +19,7 @@ class Movie < ApplicationRecord
   # 1ページの動画表示件数を指定
   PER_PAGE = 10
   # ナビゲーションバーで特に指定しない動画のジャンルをまとめて格納
-  PROGRAMMING = ["Basic", "git", "Ruby", "Ruby on Rails"].freeze
+  PROGRAMMING = ["Basic", "Git", "Ruby", "Ruby on Rails"].freeze
 
   def self.categorized_by(genre, page:)
     case genre

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -17,7 +17,7 @@ class Text < ApplicationRecord
   has_one_attached :image
 
   PER_PAGE = 10
-  PROGRAMMING = ["Basic", "git", "Ruby", "Ruby on Rails"].freeze
+  PROGRAMMING = ["Basic", "Git", "Ruby", "Ruby on Rails"].freeze
 
   def self.show_contents_list
     Text.where(genre: PROGRAMMING).order(:position)

--- a/db/migrate/20200226100517_add_position_to_text.rb
+++ b/db/migrate/20200226100517_add_position_to_text.rb
@@ -1,5 +1,5 @@
 class AddPositionToText < ActiveRecord::Migration[5.2]
-  PROGRAMMING = ["Basic", "git", "Ruby", "Ruby on Rails"].freeze
+  PROGRAMMING = ["Basic", "Git", "Ruby", "Ruby on Rails"].freeze
 
   def up
     add_column :texts, :position, :integer


### PR DESCRIPTION
## 概要

- Gitのテキスト教材を表示するように修正
- Gitのテキスト教材を管理者画面から選択可能に修正
