### PR TITLE
og:image のリンクを修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
         description: :description,
         type: "website",
         url: request.url,
-        image: twitter_image.present? ? image_tag(@text.image): image_url("texts/#{Settings.ogp.default_twitter_image}"),
+        image: twitter_image.present? ? twitter_image: image_url("texts/#{Settings.ogp.default_twitter_image}"),
         locale: "ja_JP",
       },
       twitter: {

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title) { @text.title } %>
 <% content_for(:description) { @text.description } %>
-<% @text.image.attached? ? content_for(:twitter_image) { image_tag @text.image } : content_for(:twitter_image) { @text.image } %>
+<% content_for(:twitter_image) { (image_tag @text.image).slice /http.+(\.png|\.jpg|\.gif)/ } if @text.image.attached? %>
 <section id="text-contents">
   <h2><%= @text.title %></h2>
   <% if user_signed_in? %>


### PR DESCRIPTION
## 概要

- タイトルの通り

### 補足

`og:image`に`img`タグが入っていたことにより，Twitterカードで画像が表示されていませんでした。

imgタグを除去したURLが入るように修正を行いました。