### PR TITLE
管理者画面の一覧表示の無駄を削る

### DIFF
--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -1,4 +1,13 @@
 ActiveAdmin.register Movie do
   permit_params :title, :contents, :desc, :genre
   menu parent: "動画教材"
+  config.sort_order = "position_asc"
+
+  index do
+    selectable_column
+    column :position
+    column :genre
+    column :title
+    actions
+  end
 end

--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -3,20 +3,20 @@ ActiveAdmin.register Text do
   # ドロップダウンメニューの親成分を決定
   menu parent: "テキスト教材"
   permit_params :genre, :title, :contents, :image, :description
-  config.sort_order = "id_asc"
+  config.sort_order = "position_asc"
 
   index do
     selectable_column
-    id_column
+    column :position
     column :genre
     column :title
-    column :contents
     column :description
     actions
   end
 
   show do
     attributes_table do
+      row :position
       row :genre
       row :title
       row :contents
@@ -31,6 +31,7 @@ ActiveAdmin.register Text do
 
   form do |_f|
     inputs  do
+      input :position
       input :genre, as: :select, collection: PROGRAMMING
       input :title, as: :string
       input :contents


### PR DESCRIPTION
### 背景

- Railsテキスト教材・動画教材の詳細部分が表示されているために，ページの縦幅が無駄に長くなっていた