### PR TITLE
ActiveStorageのキャッシュを5分から1ヶ月に変更

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,1 @@
+ActiveStorage::Service.url_expires_in = 1.month


### PR DESCRIPTION
## 概要

- ActiveStorageのキャッシュを5分から1ヶ月に変更

### 背景

- キャッシュがないとき，Railsテキスト教材ページの表示に10秒以上かかる状態となっているため。