### PR TITLE
画像のキャッシュ期間を修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module ErrorCollection
     config.time_zone = "Tokyo"
     config.i18n.default_locale = :ja
     config.paths.add "lib/autoloads", eager_load: true
+    ActiveStorage::Service.url_expires_in = 7.days
     config.generators do |g|
       g.test_framework :rspec,
                        view_specs: false,

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,1 +1,0 @@
-ActiveStorage::Service.url_expires_in = 1.month


### PR DESCRIPTION
## 概要

- 画像のキャッシュ期間を修正

## 備考

- 画像のキャッシュを1ヶ月にしたところ，画像が表示されない問題が発生したため，7日に修正