### PR TITLE
質問投稿時のSlack通知機能を除去

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -19,8 +19,11 @@ class QuestionsController < ApplicationController
       flash[:success] = "質問を投稿しました。"
       cookies.signed[:my_question] = { value: @question.id,
                                        expires: 1.weeks.from_now.utc }
-      notifier = Slack::Notifier.new "https://hooks.slack.com/services/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"
-      notifier.ping "質問が投稿されました"
+      # Slack通知で次のエラーが発生しているためコメントアウト
+      # Slack::Notifier::APIError (The slack API returned an error: invalid_token (HTTP Code 403)
+
+      # notifier = Slack::Notifier.new "https://hooks.slack.com/services/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"
+      # notifier.ping "質問が投稿されました"
 
       redirect_to questions_path
     else


### PR DESCRIPTION
## 概要

- 質問集で質問を投稿を投稿された際に動作していたSlack通知機能を除去

### 背景

以下のエラーが発生していることを確認したため，神里さんに相談をした結果一旦外すことに決まりました。

```
Slack::Notifier::APIError (The slack API returned an error: invalid_token (HTTP Code 403)
```