### PR TITLE
動画の並び替え機能を修正

### DIFF
--- a/app/admin/movies_sort.rb
+++ b/app/admin/movies_sort.rb
@@ -1,7 +1,8 @@
 ActiveAdmin.register_page "MovieSort" do
-  # トップメニュー「動画教材」の下に「並び替え」という名前のドロップダウンを追加
   menu parent: "動画教材", label: "並び替え"
   PROGRAMMING = Settings.programming.rails.split(", ").freeze
+  LIVE = Settings.programming.live.split(", ").freeze
+  GENERAL = Settings.programming.general.split(", ").freeze
   page_action :update, method: :patch
 
   content do
@@ -10,12 +11,16 @@ ActiveAdmin.register_page "MovieSort" do
 
   controller do
     def index
-      @pre_movies = Movie.where(genre: PROGRAMMING).order(:position)
-      @post_movies = Movie.where.not(genre: PROGRAMMING).order(:genre, :position)
-      @movies = @pre_movies + @post_movies
-      @movies.each.with_index(1) do |movie, index|
+      # 並び替え機能が正常に機能するように先に整頓を行う
+      # 「ライブコーディング」「対談」「マネタイズ講座」は新規投稿順で固定する
+      programming_movies = Movie.where(genre: PROGRAMMING).order(:position)
+      general_movies = Movie.where(genre: GENERAL).order(:genre, :position)
+      live_movies = Movie.where(genre: LIVE).order(:genre, id: :desc)
+      all_movies = programming_movies + general_movies + live_movies
+      all_movies.each.with_index(1) do |movie, index|
         movie.insert_at(index) if movie.position != index
       end
+      @movies = programming_movies + general_movies
     end
 
     def update

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -22,13 +22,16 @@ class Movie < ApplicationRecord
   PER_PAGE = 10
   # ナビゲーションバーで特に指定しない動画のジャンルをまとめて格納
   PROGRAMMING = Settings.programming.rails.split(", ").freeze
+  LIVE = Settings.programming.live.split(", ").freeze
+  GENERAL = Settings.programming.general.split(", ").freeze
 
   def self.categorized_by(genre, page:)
     case genre
-    when "Money", "Movie", "Writing", "Php", "Marketing"
+    when *GENERAL
       self.where(genre: genre).order(:position).page(page).per(PER_PAGE)
-    when "Salon", "Talk", "Live"
-      self.where(genre: genre).order(position: :desc).page(page).per(PER_PAGE)
+    when *LIVE
+      # 「ライブコーディング」「対談」「マネタイズ講座」は新規投稿順
+      self.where(genre: genre).order(id: :desc).page(page).per(PER_PAGE)
     else
       self.where(genre: PROGRAMMING).order(:position).page(page).per(PER_PAGE)
     end

--- a/app/views/admin/_movies_sort.html.erb
+++ b/app/views/admin/_movies_sort.html.erb
@@ -1,5 +1,6 @@
 <div class="admin-textsort-container">
   <p>ドラッグ＆ドロップで「動画教材」の並び順を変更できます</p>
+  <small>※「ライブコーディング」「対談」「マネタイズ講座」の並び順変更には対応しておりません</small>
   <div id="movie_sort_list" class="sort-table">
     <div class="row title">
       <div class="left-column">ジャンル</div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,5 @@ ogp:
   default_twitter_image: "no_image.jpg"
 programming:
   rails: "Basic, Git, HTML&CSS, Ruby, Ruby on Rails"
+  general: "Movie, Writing, Php, Marketing, Design, Other"
+  live: "Salon, Talk, Live, Money"


### PR DESCRIPTION
## 概要

- 動画の並び替え機能を修正

### 内容

- 動画のジャンル分けに使用している定数を追加・修正
   - 新規投稿順に並んで欲しいジャンルの定数`LIVE`を追加

- `LIVE` に含まれる動画の `postion` が他の動画より後ろに並ぶようにし，動画の並び替えページに表示されないように設定
  - 新規投稿順にすることと，動画の並び替え機能との共存が難しいため