### PR TITLE
管理者画面の SlackMenber にインポート機能を追加

### DIFF
--- a/app/admin/slack_members.rb
+++ b/app/admin/slack_members.rb
@@ -1,3 +1,4 @@
 ActiveAdmin.register SlackMember do
+  active_admin_import
   permit_params :genre, :userid, :status, :username, :fullname, :displayname
 end

--- a/app/admin/slack_members.rb
+++ b/app/admin/slack_members.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register SlackMember do
+  permit_params :genre, :userid, :status, :username, :fullname, :displayname
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,6 +22,7 @@ ja:
       money: 課金
       movie: 動画
       program: プログラム
+      slack_member: Slackメンバー
     attributes:
       admin_user:
       error:
@@ -51,6 +52,12 @@ ja:
         desc: 降順
       program:
         name: プログラム名
+      slack_member:
+        userid: メンバーID
+        username: ユーザー名
+        fullname: フルネーム
+        displayname: ニックネーム
+        status: 権限
   attributes:
     id: ID
     program_id: プログラムID


### PR DESCRIPTION
## 概要

- 管理者画面の SlackMenber にインポート機能を追加

### 内容

- 管理者画面の SlackMenber モデルを追加
- SlackMenber モデルの日本語訳を設定
- 管理者画面の SlackMenber にインポート機能を追加