### PR TITLE
Railsテキスト教材に読破済み機能を実装

### DIFF
--- a/app/assets/stylesheets/smart_phones.scss
+++ b/app/assets/stylesheets/smart_phones.scss
@@ -391,7 +391,7 @@ footer {
 }
 
 .movie-body {
-  height: 250px;
+  height: 290px;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/app/controllers/moneys_controller.rb
+++ b/app/controllers/moneys_controller.rb
@@ -1,6 +1,0 @@
-class MoneysController < ApplicationController
-  def index
-    @level = Movie.count_level(params[:page])
-    @moneys = Movie.disp_money(params[:page])
-  end
-end

--- a/app/controllers/read_texts_controller.rb
+++ b/app/controllers/read_texts_controller.rb
@@ -1,0 +1,7 @@
+class ReadTextsController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/read_texts_controller.rb
+++ b/app/controllers/read_texts_controller.rb
@@ -1,7 +1,11 @@
 class ReadTextsController < ApplicationController
   def create
+    @text_id = params[:text_id]
+    current_user.read_texts.create!(text_id: @text_id)
   end
 
   def destroy
+    @text_id = params[:text_id]
+    ReadText.find_by(user_id: current_user.id, text_id: @text_id).destroy!
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -9,5 +9,6 @@ class TextsController < ApplicationController
 
   def show
     @text = Text.find(params[:id])
+    @read_text_ids = current_user.read_texts.pluck(:text_id)
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,6 +4,7 @@ class TextsController < ApplicationController
 
   def index
     @texts = Text.show_contents_list
+    @read_text_ids = current_user.read_texts.pluck(:text_id)
   end
 
   def show

--- a/app/models/read_text.rb
+++ b/app/models/read_text.rb
@@ -13,4 +13,8 @@
 #  index_read_texts_on_user_id_and_text_id  (user_id,text_id) UNIQUE
 #
 class ReadText < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+  validates :user_id, presence: true, uniqueness: { scope: :text_id }
+  validates :text_id, presence: true
 end

--- a/app/models/read_text.rb
+++ b/app/models/read_text.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: read_texts
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  text_id    :integer          not null
+#  user_id    :integer          not null
+#
+# Indexes
+#
+#  index_read_texts_on_user_id_and_text_id  (user_id,text_id) UNIQUE
+#
+class ReadText < ApplicationRecord
+end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -15,6 +15,7 @@
 class Text < ApplicationRecord
   acts_as_list
   has_one_attached :image
+  has_many :read_texts, dependent: :destroy
 
   PER_PAGE = 10
   PROGRAMMING = Settings.programming.rails.split(", ").freeze

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,5 @@ class User < ApplicationRecord
          :rememberable, :trackable, :validatable
   validates :slack_id, presence: true, uniqueness: true
   has_many :watched_movies, dependent: :destroy
+  has_many :read_texts, dependent: :destroy
 end

--- a/app/views/read_texts/create.js.erb
+++ b/app/views/read_texts/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('read-text-<%= @text_id %>').innerHTML = '<%= j render("texts/read_text", text_id: @text_id) %>'

--- a/app/views/read_texts/destroy.js.erb
+++ b/app/views/read_texts/destroy.js.erb
@@ -1,0 +1,2 @@
+<h1>ReadTexts#destroy</h1>
+<p>Find me in app/views/read_texts/destroy.html.erb</p>

--- a/app/views/read_texts/destroy.js.erb
+++ b/app/views/read_texts/destroy.js.erb
@@ -1,2 +1,1 @@
-<h1>ReadTexts#destroy</h1>
-<p>Find me in app/views/read_texts/destroy.html.erb</p>
+document.getElementById('read-text-<%= @text_id %>').innerHTML = '<%= j render("texts/unread_text", text_id: @text_id) %>'

--- a/app/views/texts/_read_text.html.erb
+++ b/app/views/texts/_read_text.html.erb
@@ -1,0 +1,1 @@
+<object><%= link_to "読破済みを解除", text_read_texts_path(text_id), class: "btn btn-primary btn-block", method: :delete, data: { remote: true } %></object>

--- a/app/views/texts/_unread_text.html.erb
+++ b/app/views/texts/_unread_text.html.erb
@@ -1,0 +1,1 @@
+<object><%= link_to "読破済みにする", text_read_texts_path(text_id), class: "btn btn-secondary btn-block",  method: :post, data: { remote: true } %></object>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -14,7 +14,7 @@
           <% else %>
             <%= image_tag "texts/no_image.jpg", loading: "lazy" %>
           <% end %>
-          <div id="read-text-<%= text.id %>" class="text-right">
+          <div id="read-text-<%= text.id %>">
             <% if @read_text_ids.include?(text.id) %>
               <%= render "read_text", text_id: text.id %>
             <% else %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -14,9 +14,16 @@
           <% else %>
             <%= image_tag "texts/no_image.jpg", loading: "lazy" %>
           <% end %>
+          <div id="read-text-<%= text.id %>" class="text-right">
+            <% if @read_text_ids.include?(text.id) %>
+              <%= render "read_text", text_id: text.id %>
+            <% else %>
+              <%= render "unread_text", text_id: text.id %>
+            <% end %>
+          </div>
           <h3><%= text.title %></h3>
           <p><%= "【#{text.genre}】" %></p>
-        <% end %>
+      <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -5,6 +5,13 @@
   <h2><%= @text.title %></h2>
   <% if user_signed_in? %>
     <%= markdown(@text.contents).html_safe %>
+    <div id="read-text-<%= @text.id %>" class="mb-4">
+      <% if @read_text_ids.include?(@text.id) %>
+        <%= render "read_text", text_id: @text.id %>
+      <% else %>
+        <%= render "unread_text", text_id: @text.id %>
+      <% end %>
+    </div>
   <% else %>
     <p>
       記事を閲覧するには，<%= link_to "ログイン", new_user_session_path %>が必要です。
@@ -21,4 +28,5 @@
   <% end %>
   <%= social_share_button_tag(@text.title, :allow_sites => %w(twitter)) %>
   <%= social_share_button_tag(@text.title, :url => text_path(@text), :allow_sites => %w(facebook)) %>
+
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
   resources :movies, only: [:index] do
     resource :watched_movies, only: [:create, :destroy]
   end
-  resources :texts, only: [:index, :show]
+  resources :texts, only: [:index, :show] do
+    resource :read_texts, only: [:create, :destroy]
+  end
   resources :lines
   resources :moneys
   resources :salons, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,17 +11,14 @@ Rails.application.routes.draw do
   resources :aws, only: [:index, :show]
   resources :users_webs
   resources :words
-  resources :contents
   resources :movies, only: [:index] do
     resource :watched_movies, only: [:create, :destroy]
   end
   resources :texts, only: [:index, :show] do
     resource :read_texts, only: [:create, :destroy]
   end
-  resources :lines
-  resources :moneys
+  resources :lines, only: [:index, :show]
   resources :salons, only: :index
-  resources :designs
   resources :questions, only: [:index, :show, :create, :edit, :update]
   resources :questions do
     resource :solutions, only: [:create]

--- a/db/migrate/20200624135427_create_read_texts.rb
+++ b/db/migrate/20200624135427_create_read_texts.rb
@@ -1,0 +1,11 @@
+class CreateReadTexts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :read_texts do |t|
+      t.integer :user_id, null: false
+      t.integer :text_id, null: false
+
+      t.timestamps
+    end
+    add_index :read_texts, [:user_id, :text_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_114403) do
+ActiveRecord::Schema.define(version: 2020_06_24_135427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,6 +121,14 @@ ActiveRecord::Schema.define(version: 2020_06_24_114403) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "count", default: 0
+  end
+
+  create_table "read_texts", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "text_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "text_id"], name: "index_read_texts_on_user_id_and_text_id", unique: true
   end
 
   create_table "solutions", force: :cascade do |t|

--- a/spec/factories/read_texts.rb
+++ b/spec/factories/read_texts.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: read_texts
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  text_id    :integer          not null
+#  user_id    :integer          not null
+#
+# Indexes
+#
+#  index_read_texts_on_user_id_and_text_id  (user_id,text_id) UNIQUE
+#
+FactoryBot.define do
+  factory :read_text do
+    user_id { 1 }
+    text_id { 1 }
+  end
+end

--- a/spec/models/read_text_spec.rb
+++ b/spec/models/read_text_spec.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: read_texts
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  text_id    :integer          not null
+#  user_id    :integer          not null
+#
+# Indexes
+#
+#  index_read_texts_on_user_id_and_text_id  (user_id,text_id) UNIQUE
+#
+require 'rails_helper'
+
+RSpec.describe ReadText, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/read_texts_request_spec.rb
+++ b/spec/requests/read_texts_request_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "ReadTexts", type: :request do
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/read_texts/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/read_texts/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## 概要

- Railsテキスト教材に読破済み・読破済み解除の機能を実装

### 内容

- 読破済み用の中間テーブルを追加
- 読破済み・読破済み解除の機能を一覧ページ・詳細ページに実装
