### PR TITLE
テキスト教材に動画教材を表示できるように設定

### DIFF
--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Movie do
-  permit_params :title, :contents, :desc, :genre
+  permit_params :title, :contents, :desc, :genre, :text_id
   menu parent: "動画教材"
   config.sort_order = "position_asc"
 
@@ -8,6 +8,7 @@ ActiveAdmin.register Movie do
     column :position
     column :genre
     column :title
+    column :text_id
     actions
   end
 end

--- a/app/assets/stylesheets/movie.scss
+++ b/app/assets/stylesheets/movie.scss
@@ -3,3 +3,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.movie_info_box {
+  border-top: solid 5px #5d627b;
+  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.22);
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -10,5 +10,7 @@ class TextsController < ApplicationController
   def show
     @text = Text.find(params[:id])
     @read_text_ids = current_user.read_texts.pluck(:text_id)
+    @movies = @text.movies.order(:position)
+    @watched_movie_ids = current_user.watched_movies.pluck(:movie_id)
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -10,6 +10,7 @@
 #  title      :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  text_id    :integer
 #
 
 class Movie < ApplicationRecord
@@ -18,6 +19,7 @@ class Movie < ApplicationRecord
   validates :contents, presence: true
   validates :genre, presence: true
   has_many :watched_movies, dependent: :destroy
+  belongs_to :text
 
   # 1ページの動画表示件数を指定
   PER_PAGE = 18

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -16,6 +16,7 @@ class Text < ApplicationRecord
   acts_as_list
   has_one_attached :image
   has_many :read_texts, dependent: :destroy
+  has_many :movies
 
   PER_PAGE = 10
   PROGRAMMING = Settings.programming.rails.split(", ").freeze

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -11,8 +11,8 @@
             Rails
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <%= link_to "Ruby/Rails教材", texts_path, class: "dropdown-item" %>
             <%= link_to "動画教材", movies_path, class: "dropdown-item" %>
-            <%= link_to "テキスト教材", texts_path, class: "dropdown-item" %>
             <%= link_to "AWS講座", aws_path, class: "dropdown-item" %>
             <%= link_to "ライブコーディング", movies_path(genre: "Live"), class: "dropdown-item" %>
             <%= link_to "質問集", questions_path, class: "dropdown-item" %>

--- a/app/views/texts/_movie.html.erb
+++ b/app/views/texts/_movie.html.erb
@@ -1,3 +1,6 @@
+<div class="movie_info_box">
+  <p class="p-2 text-center">動画教材を視聴された上で，テキスト教材を元に手を動かすようにして下さい。</p>
+</div>
 <div class="container-fluid">
   <div class="row justify-content-md-center">
     <% @movies.each do |movie| %>

--- a/app/views/texts/_movie.html.erb
+++ b/app/views/texts/_movie.html.erb
@@ -1,0 +1,27 @@
+<div class="container-fluid">
+  <div class="row justify-content-md-center">
+    <% @movies.each do |movie| %>
+      <div class="col-12 col-md-6">
+        <div class="card border-dark mb-3">
+          <div class="card-header p-0">
+            <div class="embed-responsive embed-responsive-16by9">
+              <%= movie.contents.html_safe %>
+            </div>
+          </div>
+          <div class="card-body text-dark movie-body">
+            <p id="watched-movie-<%= movie.id %>">
+              <% if @watched_movie_ids.include?(movie.id) %>
+                <%= render "movies/watched_movie", movie_id: movie.id %>
+              <% else %>
+                <%= render "movies/unwatched_movie", movie_id: movie.id %>
+              <% end %>
+            </p>
+            <p class="card-text movie-title">
+              <%= movie.title %>
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -4,6 +4,7 @@
 <section id="text-contents">
   <h2><%= @text.title %></h2>
   <% if user_signed_in? %>
+    <%= render "movie" if @movies.present? %>
     <%= markdown(@text.contents).html_safe %>
     <div id="read-text-<%= @text.id %>" class="mb-4">
       <% if @read_text_ids.include?(@text.id) %>
@@ -19,14 +20,13 @@
     <p class="mb-4">
       <small>
         こちらの記事は，
-        <%= link_to "人生逆転サロン", "https://utina.yoshitokamizato.com/entry/2018/09/06/202647" %>
+        <%= link_to "やんばるCODEオンライン", "https://utina.yoshitokamizato.com/entry/2018/09/06/202647" %>
         もしくは
-        <%= link_to "共同開発", "https://note.com/yoshitokamizato/n/ne9fb7cd06b46" %>
+        <%= link_to "やんばるエキスパート", "https://yanbaru-expert.com/" %>
         参加者限定の記事となっております。
       </small>
     </p>
   <% end %>
   <%= social_share_button_tag(@text.title, :allow_sites => %w(twitter)) %>
   <%= social_share_button_tag(@text.title, :url => text_path(@text), :allow_sites => %w(facebook)) %>
-
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: "movies#index"
+  root to: "texts#index"
 
   devise_for :users, controllers: {
     registrations: "users/registrations",

--- a/db/migrate/20200703075804_add_text_id_to_movies.rb
+++ b/db/migrate/20200703075804_add_text_id_to_movies.rb
@@ -1,0 +1,5 @@
+class AddTextIdToMovies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :movies, :text_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_135427) do
+ActiveRecord::Schema.define(version: 2020_07_03_075804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_135427) do
     t.datetime "updated_at", null: false
     t.string "genre"
     t.integer "position"
+    t.integer "text_id"
   end
 
   create_table "programs", force: :cascade do |t|

--- a/spec/factories/movies.rb
+++ b/spec/factories/movies.rb
@@ -10,6 +10,7 @@
 #  title      :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  text_id    :integer
 #
 
 FactoryBot.define do

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -10,6 +10,7 @@
 #  title      :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  text_id    :integer
 #
 
 require "rails_helper"


### PR DESCRIPTION
## 概要

- テキスト教材に動画教材を表示できるように設定

### 内容

- トップページをテキスト教材に変更
- ナビバーのRails教材の配置を修正
- `movies` テーブルに `text_id` カラムを追加
- テキスト教材に動画教材を表示できるように設定
- 管理者画面で動画教材のページからテキスト教材に表示する動画を設定できるようにする