### PR TITLE
ヘッダーのテキスト教材を選択した際はカレンダーを非表示にする

### DIFF
--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,5 +1,5 @@
 <div class="texts-wrapper">
-  <% if ENV["YANBARU_GOOGLE_CALENDAR"].present? %>
+  <% if ENV["YANBARU_GOOGLE_CALENDAR"].present? && request.path == "/" %>
     <div class="contents-title">
       <h2>やんばるCODE イベント日程</h2>
     </div>


### PR DESCRIPTION
## 概要

- ヘッダーのテキスト教材を選択した際はカレンダーを非表示にする