### PR TITLE
テキスト教材のシンタックスハイライトを最後の拡張子に指定

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -33,10 +33,10 @@ module MarkdownHelper
           if array[0].include?(".")
             # 3. app/views/layouts/application.html.erb のケース
             path = array[0]
-            lang = array[0].split(".")[1]
+            lang = array[0].split(".").last
           elsif array.length > 1
             # 4. html:app/views/layouts/application.html.erb のケース
-            path = array[1]
+            path = array.last
             lang = array[0]
           else
             # 2. html のケース


### PR DESCRIPTION
## 概要

- テキスト教材のシンタックスハイライトを最後の拡張子に指定
  - `test.html.erb` なら `erb` を利用

### 背景

`html.erb` 形式のシンタックスハイライト時に一部が赤色になる問題がありました。