### PR TITLE
テキスト教材詳細ページの読破済み「ツイートする」ボタン

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,6 @@ gem "slack-ruby-client"
 gem "turbolinks", "~> 5"
 gem "uglifier", ">= 1.3.0"
 
-# 各種SNSシェアボタンを作成
-gem "social-share-button"
-
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,13 +115,6 @@ GEM
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     coderay (1.1.3)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -391,8 +384,6 @@ GEM
       gli
       hashie
       websocket-driver
-    social-share-button (1.2.3)
-      coffee-rails
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -470,7 +461,6 @@ DEPENDENCIES
   simple_form
   slack-notifier
   slack-ruby-client
-  social-share-button
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,6 @@
 //= require jquery3
 //= require popper
 //= require bootstrap-sprockets
-//= require social-share-button
 
 // テキスト教材ページ - 検索フォーム内の処理
 $(document).on('turbolinks:load', function () {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -198,3 +198,27 @@ ul.pagination {
   }
 
 }
+
+// Twitter シェアボタン
+
+.btn-sns {
+  color: white !important;
+  width: 100%;
+
+  span {
+    transition: .6s;
+    display: inline-block;
+  }
+
+  &:hover span {
+    -webkit-transform: rotateX(360deg);
+    -ms-transform: rotateX(360deg);
+    transform: rotateX(360deg);
+    text-decoration: none;
+  }
+
+}
+
+.btn-twitter {
+  background: #55acee;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,6 @@
  *
  *= require_self
  *= require font-awesome
- *= require social-share-button
  */
 @import "bootstrap/functions";
 @import "bootstrap";

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -9,6 +9,7 @@ class TextsController < ApplicationController
 
   def show
     @text = Text.find(params[:id])
+    @next_text_id = Text.where.not(genre: "Other").find_by(position: @text.position + 1)
     if user_signed_in?
       @read_text_ids = current_user.read_texts.pluck(:text_id)
       @movies = @text.movies.order(:position)

--- a/app/views/read_texts/create.js.erb
+++ b/app/views/read_texts/create.js.erb
@@ -1,1 +1,5 @@
 document.getElementById('read-text-<%= @text_id %>').innerHTML = '<%= j render("texts/read_text", text_id: @text_id) %>'
+$readModal = $('#read-modal')
+if($readModal.length) {
+    $readModal.modal({keyboard: false}).show()
+}

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -13,7 +13,9 @@
         <%= render "unread_text", text_id: @text.id %>
       <% end %>
     </div>
-  <% elsif user_signed_in? && !(current_user.flag) %>
+    <%= social_share_button_tag(@text.title, :allow_sites => %w(twitter)) %>
+    <%= social_share_button_tag(@text.title, :url => text_path(@text), :allow_sites => %w(facebook)) %>
+<% elsif user_signed_in? && !(current_user.flag) %>
     <section class="text-center mt-5">
       <p>登録されたSlack IDは削除されております。</p>
       <p>現在参加中のサロンのSlack IDで新規登録をお願いいたします。</p>
@@ -31,7 +33,12 @@
         参加者限定の記事となっております。
       </small>
     </p>
+    <section class="advertising_banner">
+      <div class="cover text-center">
+        <%= link_to "http://yanbaru-expert.com/", target: :_blank, rel: "noopener" do %>
+          <%= image_tag "yanbaru_expert_banner.jpg", loading: "lazy" %>
+        <% end %>
+      </div>
+    </section>
   <% end %>
-  <%= social_share_button_tag(@text.title, :allow_sites => %w(twitter)) %>
-  <%= social_share_button_tag(@text.title, :url => text_path(@text), :allow_sites => %w(facebook)) %>
 </section>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -13,9 +13,30 @@
         <%= render "unread_text", text_id: @text.id %>
       <% end %>
     </div>
-    <%= social_share_button_tag(@text.title, :allow_sites => %w(twitter)) %>
-    <%= social_share_button_tag(@text.title, :url => text_path(@text), :allow_sites => %w(facebook)) %>
-<% elsif user_signed_in? && !(current_user.flag) %>
+    <div class="modal fade" id="read-modal" tabindex="-1" role="dialog" aria-labelledby="read-modal-title" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="read-modal-title">読破おつかれさまです！</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>『<%= @text.title %>』を読破しました。</p>
+            <a href="https://twitter.com/intent/tweet?url=<%= request.url %>&text=『<%= @text.title %>』を読破しました！&hashtags=やんばるCODE&hashtags=やんばるエキスパート&" class="btn btn-sns btn-twitter" target="_blank" rel="noopener">
+              <%= fa_icon "twitter" %> <span>ツイートする </span>
+            </a>
+          </div>
+          <% if @next_text_id.present? %>
+            <div class="modal-footer">
+              <%= link_to "次の教材にすすむ", text_path(@next_text_id), class: "btn btn-primary btn-block" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% elsif user_signed_in? && !(current_user.flag) %>
     <section class="text-center mt-5">
       <p>登録されたSlack IDは削除されております。</p>
       <p>現在参加中のサロンのSlack IDで新規登録をお願いいたします。</p>

--- a/config/initializers/social_share_button.rb
+++ b/config/initializers/social_share_button.rb
@@ -1,5 +1,0 @@
-SocialShareButton.configure do |config|
-  config.allow_sites = %w[twitter facebook] # google_plus weibo qq douban google_bookmark
-  # delicious tumblr pinterest email linkedin wechat vkontakte
-  # xing reddit hacker_news telegram odnoklassniki whatsapp_app whatsapp_web)
-end


### PR DESCRIPTION
## 概要

- テキスト教材詳細ページの読破済みボタン押下時に「ツイートする」ボタンの入ったモーダルを表示する機能を実装

### 内容

- ログアウト時のテキスト教材の詳細ページに「やんばるエキスパート」のバナーを設置
- `social-share-button` の gem と関連する記述を削除
  - アイコンをデフォルトから変更できないため
- 読破済みボタン押下時に「ツイートする」「次の教材へすすむ」ボタンの入ったモーダルを表示する機能を実装