### PR TITLE
Twitter 用の画像URLの書き方を修正

### DIFF
--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -16,7 +16,7 @@
       <div class="texts-content">
         <%= link_to text_path(text.id), { :target => "_blank" } do %>
           <% if text.image.attached? %>
-            <%= image_tag text.image, loading: "lazy" %>
+            <img src="<%= text.image.attachment.service.send(:object_for, text.image.key).public_url %>" alt="<%= text.title %>" loading="lazy">
           <% else %>
             <%= image_tag "texts/no_image.jpg", loading: "lazy" %>
           <% end %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title) { @text.title } %>
 <% content_for(:description) { @text.description } %>
-<% content_for(:twitter_image) { (image_tag @text.image).slice /http.+(\.png|\.jpg|\.gif)/ } if @text.image.attached? %>
+<% content_for(:twitter_image) { @text.image.attachment.service.send(:object_for, @text.image.key).public_url } if @text.image.attached? %>
 <section id="text-contents">
   <h2><%= @text.title %></h2>
   <% if user_signed_in? && current_user.flag %>


### PR DESCRIPTION
## 背景

- Twitter 用の画像が表示されていなかった

### 内容

- AWS S3 の画像のパスを直接指定する形式に変更
  - ついでに画像のキャッシュ期間を変更できているかも？