### PR TITLE
PHP講座をLINE@の左へ移動

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -19,9 +19,6 @@
           </div>
         </li>
         <li class="nav-item">
-          <%= link_to "PHP講座", movies_path(genre: "Php"), class: "nav-item nav-link active" %>
-        </li>
-        <li class="nav-item">
           <%= link_to "対談", movies_path(genre: "Talk"), class: "nav-item nav-link active" %>
         </li>
         <li class="nav-item">
@@ -35,6 +32,9 @@
         </li>
         <li class="nav-item">
           <%= link_to "マネタイズ講座", movies_path(genre: "Money"), class: "nav-item nav-link active" %>
+        </li>
+        <li class="nav-item">
+        <%= link_to "PHP講座", movies_path(genre: "Php"), class: "nav-item nav-link active" %>
         </li>
         <li class="nav-item">
           <%= link_to "LINE@", lines_path, class: "nav-item nav-link active" %>


### PR DESCRIPTION
#181 のissueです。

ナビバーの位置を変更しました。
「PHP講座」を「LINE@」左にしています。
確認をお願いします。

