### PR TITLE
Feature/added new menu of activeadmin for php text contents

### DIFF
--- a/app/admin/movies_sort.rb
+++ b/app/admin/movies_sort.rb
@@ -1,8 +1,5 @@
 ActiveAdmin.register_page "MovieSort" do
   menu parent: "動画教材", label: "並び替え"
-  PROGRAMMING = Settings.programming.rails.split(", ").freeze
-  LIVE = Settings.programming.live.split(", ").freeze
-  GENERAL = Settings.programming.general.split(", ").freeze
   page_action :update, method: :patch
 
   content do

--- a/app/admin/movies_sort.rb
+++ b/app/admin/movies_sort.rb
@@ -13,9 +13,9 @@ ActiveAdmin.register_page "MovieSort" do
     def index
       # 並び替え機能が正常に機能するように先に整頓を行う
       # 「ライブコーディング」「対談」は新規投稿順で固定する
-      programming_movies = Movie.where(genre: PROGRAMMING).order(:position)
-      general_movies = Movie.where(genre: GENERAL).order(:genre, :position)
-      live_movies = Movie.where(genre: LIVE).order(:genre, id: :desc)
+      programming_movies = Movie.where(genre: Movie::PROGRAMMING).order(:position)
+      general_movies = Movie.where(genre: Movie::GENERAL).order(:genre, :position)
+      live_movies = Movie.where(genre: Movie::LIVE).order(:genre, id: :desc)
       all_movies = programming_movies + general_movies + live_movies
       all_movies.each.with_index(1) do |movie, index|
         movie.insert_at(index) if movie.position != index

--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -1,5 +1,7 @@
 ActiveAdmin.register Text do
-  PROGRAMMING = Settings.programming.rails.split(", ").freeze
+  # PROGRAMMING = [ Settings.programming.rails,
+  #                 Settings.programming.php].join(", ").split(", ").freeze
+
   # ドロップダウンメニューの親成分を決定
   menu parent: "テキスト教材"
   permit_params :genre, :title, :contents, :image, :description

--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register Text do
-  # PROGRAMMING = [ Settings.programming.rails,
-  #                 Settings.programming.php].join(", ").split(", ").freeze
+
+  PROGRAMMING = Settings.programming.rails.split(", ").freeze
+  SELECT_PROGRAMMINGS = PROGRAMMING.dup << Settings.programming.php
 
   # ドロップダウンメニューの親成分を決定
   menu parent: "テキスト教材"
@@ -34,7 +35,7 @@ ActiveAdmin.register Text do
   form do |_f|
     inputs  do
       input :position
-      input :genre, as: :select, collection: PROGRAMMING
+      input :genre, as: :select, collection: SELECT_PROGRAMMINGS
       input :title, as: :string
       input :contents
       input :image, as: :file

--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -1,8 +1,5 @@
 ActiveAdmin.register Text do
 
-  PROGRAMMING = Settings.programming.rails.split(", ").freeze
-  SELECT_PROGRAMMINGS = PROGRAMMING.dup << Settings.programming.php
-
   # ドロップダウンメニューの親成分を決定
   menu parent: "テキスト教材"
   permit_params :genre, :title, :contents, :image, :description
@@ -35,7 +32,7 @@ ActiveAdmin.register Text do
   form do |_f|
     inputs  do
       input :position
-      input :genre, as: :select, collection: SELECT_PROGRAMMINGS
+      input :genre, as: :select, collection: Text::ALL_PROGRAMMING
       input :title, as: :string
       input :contents
       input :image, as: :file

--- a/app/admin/texts_sort.rb
+++ b/app/admin/texts_sort.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register_page "TextSort" do
+
   # トップメニュー「テキスト教材」の下に「並び替え」という名前のドロップダウンを追加
   menu parent: "テキスト教材", label: "並び替え"
 

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,8 +3,14 @@ class TextsController < ApplicationController
   skip_before_action :approval_user!
 
   def index
-    @texts = Text.show_contents_list
-    @read_text_ids = current_user.read_texts.pluck(:text_id)
+    @contents = PROGRAMMING
+    if params[:genre].nil?
+      @texts = Text.show_contents_list
+      @read_text_ids = current_user.read_texts.pluck(:text_id)
+    elsif params[:genre] == "Php"
+      @texts = Text.where(genre: "Php")
+      @read_text_ids = current_user.read_texts.pluck(:text_id)
+    end
   end
 
   def show

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,7 +3,6 @@ class TextsController < ApplicationController
   skip_before_action :approval_user!
 
   def index
-    @contents = PROGRAMMING
     if params[:genre].nil?
       @texts = Text.show_contents_list
       @read_text_ids = current_user.read_texts.pluck(:text_id)

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -24,9 +24,9 @@ class Movie < ApplicationRecord
   # 1ページの動画表示件数を指定
   PER_PAGE = 18
   # ナビゲーションバーで特に指定しない動画のジャンルをまとめて格納
-  PROGRAMMING = Settings.programming.rails.split(", ").freeze
-  LIVE = Settings.programming.live.split(", ").freeze
-  GENERAL = Settings.programming.general.split(", ").freeze
+  PROGRAMMING = Text::PROGRAMMING
+  LIVE = ["Salon", "Talk", "Live"]
+  GENERAL = ["Movie", "Writing", "Php", "Marketing", "Design", "Other", "Money"]
 
   def self.categorized_by(genre, page:)
     case genre

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -20,7 +20,8 @@ class Text < ApplicationRecord
 
   PER_PAGE = 10
 
-  PROGRAMMING = Settings.programming.rails.split(", ").freeze
+  PROGRAMMING = ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]
+  ALL_PROGRAMMING = PROGRAMMING + ["Php"]
 
   def self.show_contents_list
     Text.where(genre: PROGRAMMING).order(:position)

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -20,12 +20,9 @@ class Text < ApplicationRecord
 
   PER_PAGE = 10
 
-  PROGRAMMING = [ Settings.programming.rails,
-                  Settings.programming.php].join(", ").split(", ").freeze
-
-  PRIMARY_CONTENTS = Settings.programming.rails.split(", ").freeze
+  PROGRAMMING = Settings.programming.rails.split(", ").freeze
 
   def self.show_contents_list
-    Text.where(genre: PRIMARY_CONTENTS).order(:position)
+    Text.where(genre: PROGRAMMING).order(:position)
   end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -19,9 +19,13 @@ class Text < ApplicationRecord
   has_many :movies
 
   PER_PAGE = 10
-  PROGRAMMING = Settings.programming.rails.split(", ").freeze
+
+  #PROGRAMMING = [ Settings.programming.rails,
+  #                Settings.programming.php].join(", ").split(", ").freeze
+
+  PRIMARY_CONTENTS = Settings.programming.rails.split(", ").freeze
 
   def self.show_contents_list
-    Text.where(genre: PROGRAMMING).order(:position)
+    Text.where(genre: PRIMARY_CONTENTS).order(:position)
   end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -20,8 +20,8 @@ class Text < ApplicationRecord
 
   PER_PAGE = 10
 
-  #PROGRAMMING = [ Settings.programming.rails,
-  #                Settings.programming.php].join(", ").split(", ").freeze
+  PROGRAMMING = [ Settings.programming.rails,
+                  Settings.programming.php].join(", ").split(", ").freeze
 
   PRIMARY_CONTENTS = Settings.programming.rails.split(", ").freeze
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -33,8 +33,14 @@
         <li class="nav-item">
           <%= link_to "マネタイズ講座", movies_path(genre: "Money"), class: "nav-item nav-link active" %>
         </li>
-        <li class="nav-item">
-        <%= link_to "PHP講座", movies_path(genre: "Php"), class: "nav-item nav-link active" %>
+        <li class="nav-item active dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            PHP
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <%= link_to "PHPテキスト教材", texts_path, class: "dropdown-item" %>
+            <%= link_to "PHP動画教材", movies_path(genre: "Php"), class: "dropdown-item" %>
+          </div>
         </li>
         <li class="nav-item">
           <%= link_to "LINE@", lines_path, class: "nav-item nav-link active" %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -38,7 +38,7 @@
             PHP
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <%= link_to "PHPテキスト教材", texts_path, class: "dropdown-item" %>
+            <%= link_to "PHPテキスト教材", texts_path(genre: "Php"), class: "dropdown-item" %>
             <%= link_to "PHP動画教材", movies_path(genre: "Php"), class: "dropdown-item" %>
           </div>
         </li>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -9,6 +9,7 @@
   <% end %>
   <div class="contents-title">
     <h2>テキスト教材</h2>
+    <h2><%= @contents %></h2>
   </div>
   <%= render 'shared/search_text' %>
   <div class="texts-contents">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -9,7 +9,6 @@
   <% end %>
   <div class="contents-title">
     <h2>テキスト教材</h2>
-    <h2><%= @contents %></h2>
   </div>
   <%= render 'shared/search_text' %>
   <div class="texts-contents">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,8 +3,3 @@ ogp:
   twitter_site: "@yoshito410kam"
   default_description: "人生逆転サロンの教材です"
   default_twitter_image: "no_image.jpg"
-programming:
-  rails: "Basic, Git, HTML&CSS, Ruby, Ruby on Rails"
-  php: "Php"
-  general: "Movie, Writing, Php, Marketing, Design, Other, Money"
-  live: "Salon, Talk, Live"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,7 @@ ogp:
   default_description: "人生逆転サロンの教材です"
   default_twitter_image: "no_image.jpg"
 programming:
-  rails: "Basic, Git, HTML&CSS, Ruby, Ruby on Rails"
+  rails: "Basic, Git, HTML&CSS, Ruby, Ruby on Rails, Php"
+  # php: "Php"
   general: "Movie, Writing, Php, Marketing, Design, Other, Money"
   live: "Salon, Talk, Live"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ ogp:
   default_description: "人生逆転サロンの教材です"
   default_twitter_image: "no_image.jpg"
 programming:
-  rails: "Basic, Git, HTML&CSS, Ruby, Ruby on Rails, Php"
-  # php: "Php"
+  rails: "Basic, Git, HTML&CSS, Ruby, Ruby on Rails"
+  php: "Php"
   general: "Movie, Writing, Php, Marketing, Design, Other, Money"
   live: "Salon, Talk, Live"


### PR DESCRIPTION
## タスク：PHPのテキスト教材を表示 #188
#### PHPテキスト教材リンクをナビバーに追加
- 管理者画面から教材を投稿できるようにする
- 管理者画面から教材の順序を変更できるようにする
- 教材を追加する（スタイルの調整もを行う）
- 教材記事はこちら
https://github.com/shimotaroo/gyakuten_php
---

管理者画面のナビメニューより「テキスト教材」を選択して、「テキスト教材を作成する」ボタンをクリックすると
表示される「テキスト教材を作成する」画面でPhpテキスト教材を登録できるようにしました。
- 当画面の「ジャンル」に Php が選択できるようにした。
- 管理者画面から教材を登録できることを確認した。
- 「やんばるCODE」ナビバーの「PHP」プルダウンメニュー内「PHPテキスト教材」をクリックで一覧表示されることを確認した。


