### PR TITLE
新規登録ページのSlack IDの確認方法をモーダルで表示

### DIFF
--- a/app/views/devise/registrations/_slack_modal.html.erb
+++ b/app/views/devise/registrations/_slack_modal.html.erb
@@ -1,0 +1,25 @@
+<div class="modal fade" id="slack-id-modal" tabindex="-1" role="dialog" aria-labelledby="slack-id-desc" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="slack-id-desc">Slack IDの確認方法</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p style="color: red;">【注】PCで以下の操作を行って下さい</p>
+        <p>①Slackアプリ画面右上のアイコンをクリック</p>
+        <%= image_tag 'https://d5izmuz0mcjzz.cloudfront.net/texts/slack/desc_slack_id_1.png', class: "d-block mx-auto mb-5" %>
+        <p>②プロフィールを表示</p>
+        <%= image_tag 'https://d5izmuz0mcjzz.cloudfront.net/texts/slack/desc_slack_id_2.png', class: "d-block mx-auto mb-5" %>
+        <p>③その他をクリック。表示されたメンバーIDをコピー</p>
+        <%= image_tag 'https://d5izmuz0mcjzz.cloudfront.net/texts/slack/desc_slack_id_3.png', class: "d-block mx-auto mb-5" %>
+        <%= image_tag 'https://d5izmuz0mcjzz.cloudfront.net/texts/slack/desc_slack_id_4.png', class: "d-block mx-auto mb-5" %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,36 +1,29 @@
 <h1><%= t('.sign_up') %></h1>
-
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= bootstrap_devise_error_messages! %>
-
   <div class="form-group">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control', required: true %>
   </div>
-
   <div class="form-group">
     <%= f.label :slack_id %>
     <%= f.text_field :slack_id, autofocus: true, class: 'form-control', minlength: 6 %>
-    <small>「Slack メンバー ID」の調べ方は <a href="http://help.receptionist.jp/?p=1100#memberid" target="_blank" rel="noopener">こちら</a></small>
+    <small>「Slack メンバー ID」の調べ方は <a href="#" data-toggle="modal" data-target="#slack-id-modal">こちら</a></small>
   </div>
-
   <div class="form-group">
     <%= f.label :password %>
     <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control', minlength: 6 %>
-
     <% if @minimum_password_length %>
       <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
     <% end %>
   </div>
-
   <div class="form-group">
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control', minlength: 6 %>
   </div>
-
   <div class="form-group">
     <%= f.submit t('.sign_up'), class: 'btn btn-primary btn-block' %>
   </div>
 <% end %>
-
 <%= render 'devise/shared/links' %>
+<%= render 'slack_modal' %>


### PR DESCRIPTION
## 内容

- モーダルを追加し, 新規登録ページでレンダリング