### PR TITLE
タイトルをやんばるCODE教材に修正

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 ogp:
-  site_name: "逆転教材"
+  site_name: "やんばるCODE教材"
   twitter_site: "@yoshito410kam"
-  default_description: "人生逆転サロンの教材です"
+  default_description: "やんばるCODEの教材です"
 genre:
   Basic:
     display_name: "Basic"


### PR DESCRIPTION
## 実装内容

- タブに表示されるタイトルを「逆転教材」から「やんばるCODE教材」に修正

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行
