### PR TITLE
Markdown内の画像がはみ出ないようにスタイルを調整

### DIFF
--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -60,6 +60,13 @@
     word-break: break-all;
   }
 
+  img {
+    display: block;
+    max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   // テーブル
 
   table {


### PR DESCRIPTION
## 実装内容

- Markdown内の画像がはみ出ないようにスタイルを調整

