### PR TITLE
情報発信・動画編集講座・ライティング講座のリンクを削除

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -71,12 +71,9 @@ h4 {
 }
 
 // ヘッダー
-@media screen and (min-width: 992px) {
-  .header-nav {
-    font-size: 0.8rem;
-    margin: 0 auto;
-    width: var(--breakpoint-lg);
-  }
+.header-nav {
+  font-size: 0.8rem;
+  margin: 0 auto;
 }
 
 .navbar-collapse {

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -26,8 +26,8 @@ class Movie < ApplicationRecord
   # ナビゲーションバーで特に指定しない動画のジャンルをまとめて格納
   PROGRAMMING = Text::PROGRAMMING
   LIVE = ["Salon", "Talk", "Live"].freeze
-  GENERAL = ["Movie", "Writing", "Php", "Marketing", "Design", "Other", "Money"].freeze
-  MYPAGE_LIST = ["Basic", "Git", "Ruby", "Ruby on Rails", "Live", "Talk", "Marketing", "Movie", "Writing", "Money", "Php"].freeze
+  GENERAL = ["Php", "Design", "Other", "Money"].freeze
+  MYPAGE_LIST = ["Basic", "Git", "Ruby", "Ruby on Rails", "Live", "Talk", "Money", "Php"].freeze
 
   def self.categorized_by(genre, page:)
     case genre

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -18,21 +18,6 @@
             <%= link_to "質問集", questions_path, class: "dropdown-item" %>
           </div>
         </li>
-        <li class="nav-item">
-          <%= link_to Settings.genre.Talk.display_name, movies_path(genre: "Talk"), class: "nav-item nav-link active" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to Settings.genre.Marketing.display_name, movies_path(genre: "Marketing"), class: "nav-item nav-link active" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to Settings.genre.Movie.display_name, movies_path(genre: "Movie"), class: "nav-item nav-link active" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to Settings.genre.Writing.display_name, movies_path(genre: "Writing"), class: "nav-item nav-link active" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to Settings.genre.Money.display_name, movies_path(genre: "Money"), class: "nav-item nav-link active" %>
-        </li>
         <li class="nav-item active dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             PHP
@@ -41,6 +26,12 @@
             <%= link_to "PHPテキスト教材", texts_path(genre: "Php"), class: "dropdown-item" %>
             <%= link_to "PHP動画教材", movies_path(genre: "Php"), class: "dropdown-item" %>
           </div>
+        </li>
+        <li class="nav-item">
+          <%= link_to Settings.genre.Talk.display_name, movies_path(genre: "Talk"), class: "nav-item nav-link active" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to Settings.genre.Money.display_name, movies_path(genre: "Money"), class: "nav-item nav-link active" %>
         </li>
         <li class="nav-item">
           <%= link_to "LINE@", lines_path, class: "nav-item nav-link active" %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,5 +1,5 @@
 <header class="fixed-top <%= base_color %>">
-  <nav class="navbar navbar-expand-lg navbar-dark header-nav">
+  <nav class="navbar navbar-expand-md mw-md navbar-dark header-nav">
     <%= link_to "やんばるCODE", root_path, class: "navbar-brand" %>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,15 +30,6 @@ genre:
   Live:
     display_name: "プログラミング勉強会"
     color_code: "#f08080"
-  Marketing:
-    display_name: "情報発信"
-    color_code: "#ffc107"
-  Movie:
-    display_name: "動画編集講座"
-    color_code: "#20c997"
-  Writing:
-    display_name: "ライティング講座"
-    color_code: "#00bfff"
   AWS:
     display_name: "AWS"
     color_code: "#ec7211"


### PR DESCRIPTION
## 実装内容

- 情報発信・動画編集講座・ライティング講座のリンクを削除
- リンク削除に伴いナビバーの配置を修正

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行
