### PR TITLE
ナビバーにフロント教材を追加

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,7 +15,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if Rails.env.production?
       # SlackAPIで入力された Slack メンバー ID が存在し，削除済みでないかを確認
       # 問題がない場合は自動で承認済み扱いとする
-      Rails.application.credentials.dig(:slack, :oauth_token).keys.each do |slack_name|
+      Rails.application.credentials.dig(:slack, :oauth_token).each_key do |slack_name|
         client = AutoSlackApproval.new(slack_name: slack_name, slack_id: resource.slack_id)
         resource.flag = client.approval?
         if resource.flag
@@ -29,7 +29,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
     if resource.flag
       # 以下は元ソース通り
-      resource.save
+      resource.save!
       yield resource if block_given?
       if resource.persisted?
         if resource.active_for_authentication?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,7 +22,7 @@ class Users::SessionsController < Devise::SessionsController
         client = AutoSlackApproval.new(slack_name: resource.slack_name.to_sym, slack_id: resource.slack_id)
         resource.flag = client.approval?
       else
-        Rails.application.credentials.dig(:slack, :oauth_token).keys.each do |slack_name|
+        Rails.application.credentials.dig(:slack, :oauth_token).each_key do |slack_name|
           client = AutoSlackApproval.new(slack_name: slack_name, slack_id: resource.slack_id)
           resource.flag = client.approval?
           if resource.flag

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -21,8 +21,8 @@ class Text < ApplicationRecord
 
   PER_PAGE = 10
 
-  PROGRAMMING = ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"].freeze
-  OTHER_PROGRAMMING = ["PHP", "AWS"].freeze
+  PROGRAMMING = ["Basic", "Git", "Ruby", "Ruby on Rails"].freeze
+  OTHER_PROGRAMMING = %w[PHP AWS HTML&CSS JavaScript TypeScript Vue].freeze
   ALL_PROGRAMMING = PROGRAMMING + OTHER_PROGRAMMING
 
   def self.show_contents_list

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -28,6 +28,17 @@
             <%= link_to "PHP動画教材", movies_path(genre: "PHP"), class: "dropdown-item" %>
           </div>
         </li>
+        <li class="nav-item active dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            フロント
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <%= link_to "HTML&CSS", texts_path(genre: "HTML&CSS"), class: "dropdown-item" %>
+            <%= link_to "JavaScript", texts_path(genre: "JavaScript"), class: "dropdown-item" %>
+            <%= link_to "TypeScript", texts_path(genre: "TypeScript"), class: "dropdown-item" %>
+            <%= link_to "Vue", texts_path(genre: "Vue"), class: "dropdown-item" %>
+          </div>
+        </li>
         <li class="nav-item">
           <%= link_to Settings.genre.Talk.display_name, movies_path(genre: "Talk"), class: "nav-item nav-link active" %>
         </li>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -9,7 +9,7 @@
     </div>
   <% end %>
   <div class="contents-title text-center">
-    <h1>テキスト教材</h1>
+    <h1><%= params[:genre] || "Rails" %> テキスト教材</h1>
   </div>
   <%= render 'shared/search_text' %>
   <div class="row">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,7 +84,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,12 +4,12 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,9 +9,6 @@ genre:
   Git:
     display_name: "Git"
     color_code: "#343a40"
-  HTML&CSS:
-    display_name: "HTML&CSS"
-    color_code: "#ffc107"
   Ruby:
     display_name: "Ruby"
     color_code: "#dc3545"
@@ -21,6 +18,18 @@ genre:
   PHP:
     display_name: "PHP"
     color_code: "#6f42c1"
+  HTML&CSS:
+    display_name: "HTML&CSS"
+    color_code: "#ffc107"
+  JavaScript:
+    display_name: "JavaScript"
+    color_code: "#e6dc00"
+  TypeScript:
+    display_name: "TypeScript"
+    color_code: "#777777"
+  Vue:
+    display_name: "Vue"
+    color_code: "#42b983"
   Money:
     display_name: "マネタイズ講座"
     color_code: "#4169e1"


### PR DESCRIPTION
## 実装内容

- ナビバーに「フロント」の項目を追加
- テキスト教材のジャンルに「JavaScript」「TypeScript」「Vue」を追加
- 進捗管理用の日本語情報を追加

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

<img width="469" alt="スクリーンショット 2021-01-13 16 16 40" src="https://user-images.githubusercontent.com/52148373/104418728-bc845800-55ba-11eb-8a90-25d76e3283c2.png">
