### PR TITLE
動画教材の URL の対応範囲を増やす

### DIFF
--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Movie do
-  permit_params :title, :contents, :desc, :genre, :text_id
+  permit_params :title, :url, :desc, :genre, :text_id
   menu parent: "動画教材"
   config.sort_order = "position_asc"
 

--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -11,4 +11,17 @@ ActiveAdmin.register Movie do
     column :text_id
     actions
   end
+
+  form do |_f|
+    inputs do
+      input :position
+      input :text
+      input :genre, as: :select, collection: Movie::MYPAGE_LIST
+      input :title
+      input :url
+      input :desc
+    end
+
+    actions
+  end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,12 @@
+module MoviesHelper
+  def embed_youtube(url)
+    tag.iframe(
+      width: 560,
+      height: 315,
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true
+    )
+  end
+end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -6,7 +6,7 @@ module MoviesHelper
       src: url,
       frameborder: 0,
       allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
-      allowfullscreen: true
+      allowfullscreen: true,
     )
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -3,11 +3,11 @@
 # Table name: movies
 #
 #  id         :bigint           not null, primary key
-#  contents   :text
 #  desc       :text
 #  genre      :string
 #  position   :integer
 #  title      :text
+#  url        :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  text_id    :integer
@@ -16,7 +16,7 @@
 class Movie < ApplicationRecord
   acts_as_list
   validates :title, presence: true
-  validates :contents, presence: true
+  validates :url, presence: true
   validates :genre, presence: true
   has_many :watched_movies, dependent: :destroy
   belongs_to :text, optional: true

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -14,7 +14,9 @@
 #
 
 class Movie < ApplicationRecord
+  YOUTUBE_REGEX = %r{\Ahttps://www.youtube.com/embed/[^?&"'>]+\z}
   acts_as_list
+
   validates :title, presence: true
   validates :url, presence: true
   validates :genre, presence: true
@@ -28,6 +30,15 @@ class Movie < ApplicationRecord
   LIVE = ["Salon", "Talk", "Live"].freeze
   GENERAL = ["PHP", "Design", "Other", "Money"].freeze
   MYPAGE_LIST = ["Basic", "Git", "Ruby", "Ruby on Rails", "PHP", "Live", "Talk", "Money"].freeze
+
+  before_save do
+    format_url = YoutubeUrlFormatter.format(url)
+    if format_url.present?
+      self.url = format_url
+    else
+      self.errors.add(:url, "YouTubeのURL以外は無効です")
+    end
+  end
 
   def self.categorized_by(genre, page:)
     case genre

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -5,7 +5,7 @@
         <div class="card border-dark mb-3">
           <div class="card-header p-0">
             <div class="embed-responsive embed-responsive-16by9">
-              <%= movie.url.html_safe %>
+              <%= embed_youtube(movie.url) %>
             </div>
           </div>
           <div class="card-body text-dark movie-body">

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -5,7 +5,7 @@
         <div class="card border-dark mb-3">
           <div class="card-header p-0">
             <div class="embed-responsive embed-responsive-16by9">
-              <%= movie.contents.html_safe %>
+              <%= movie.url.html_safe %>
             </div>
           </div>
           <div class="card-body text-dark movie-body">

--- a/app/views/texts/_movie.html.erb
+++ b/app/views/texts/_movie.html.erb
@@ -8,7 +8,7 @@
         <div class="card border-dark mb-3">
           <div class="card-header p-0">
             <div class="embed-responsive embed-responsive-16by9">
-              <%= movie.contents.html_safe %>
+              <%= movie.url.html_safe %>
             </div>
           </div>
           <div class="card-body text-dark movie-body">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -41,7 +41,6 @@ ja:
         question: 質問
       text:
       users_web:
-        url: URL
         name: 用途
       word:
         about: 言及
@@ -76,6 +75,7 @@ ja:
     description: Twitterカードの説明
     content: 内容
     contents: 内容
+    url: URL
     body: 内容
     namespace: 名前空間
     resource_type: リソースタイプ

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -48,7 +48,7 @@ ja:
       line:
       money:
       movie:
-        desc: 降順
+        desc: 説明
       program:
         name: プログラム名
       slack_member:

--- a/db/migrate/20210220083149_rename_contents_to_movies.rb
+++ b/db/migrate/20210220083149_rename_contents_to_movies.rb
@@ -1,0 +1,5 @@
+class RenameContentsToMovies < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :movies, :contents, :url
+  end
+end

--- a/db/migrate/20210220121529_format_url_to_movies.rb
+++ b/db/migrate/20210220121529_format_url_to_movies.rb
@@ -1,0 +1,7 @@
+class FormatUrlToMovies < ActiveRecord::Migration[5.2]
+  def up
+    Movie.all.each do |movie|
+      movie.update!(url: YoutubeUrlFormatter.format(movie.url))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_083149) do
+ActiveRecord::Schema.define(version: 2021_02_20_121529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_21_051405) do
+ActiveRecord::Schema.define(version: 2021_02_20_083149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2020_12_21_051405) do
 
   create_table "movies", force: :cascade do |t|
     t.text "title"
-    t.text "contents"
+    t.text "url"
     t.text "desc"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/autoloads/import.rb
+++ b/lib/autoloads/import.rb
@@ -8,7 +8,7 @@ class Import
     CSV.foreach(path, headers: true) do |row|
       data_list << {
         title: row["Title"],
-        contents: row["Contents"],
+        url: row["Contents"],
         desc: row["Desc"],
         genre: row["Genre"],
       }

--- a/lib/autoloads/youtube_url_formatter.rb
+++ b/lib/autoloads/youtube_url_formatter.rb
@@ -1,0 +1,13 @@
+class YoutubeUrlFormatter
+  SRC_REGEX = %r{src\s*=\s*"([^"]*)"}
+  YOUTUBE_ID_REGEX = %r{\A(?:http(?:s)?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:(?:watch)?\?(?:.*&)?v(?:i)?=|(?:embed|v|vi|user)\/))([^?&"'>]+)(&t=.*)?\z}
+
+  def self.format(url)
+    src_match = SRC_REGEX.match(url)
+    url = src_match[1] if src_match
+    youtube_id_match = YOUTUBE_ID_REGEX.match(url)
+    if youtube_id_match
+      "https://www.youtube.com/embed/#{youtube_id_match[1]}"
+    end
+  end
+end

--- a/lib/autoloads/youtube_url_formatter.rb
+++ b/lib/autoloads/youtube_url_formatter.rb
@@ -1,6 +1,6 @@
 class YoutubeUrlFormatter
-  SRC_REGEX = %r{src\s*=\s*"([^"]*)"}
-  YOUTUBE_ID_REGEX = %r{\A(?:http(?:s)?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:(?:watch)?\?(?:.*&)?v(?:i)?=|(?:embed|v|vi|user)\/))([^?&"'>]+)(&t=.*)?\z}
+  SRC_REGEX = /src\s*=\s*"([^"]*)"/
+  YOUTUBE_ID_REGEX = %r{\A(?:http(?:s)?://)?(?:www\.)?(?:m\.)?(?:youtu\.be/|youtube\.com/(?:(?:watch)?\?(?:.*&)?v(?:i)?=|(?:embed|v|vi|user)/))([^?&"'>]+)(&t=.*)?\z}
 
   def self.format(url)
     src_match = SRC_REGEX.match(url)

--- a/spec/factories/movies.rb
+++ b/spec/factories/movies.rb
@@ -3,11 +3,11 @@
 # Table name: movies
 #
 #  id         :bigint           not null, primary key
-#  contents   :text
 #  desc       :text
 #  genre      :string
 #  position   :integer
 #  title      :text
+#  url        :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  text_id    :integer
@@ -16,7 +16,7 @@
 FactoryBot.define do
   factory :movie do
     sequence(:title) {|n| "#{n}_#{Faker::University.name}" }
-    sequence(:contents) {|n| "#{n}_#{Faker::Commerce.department}" }
+    sequence(:url) {|n| "#{n}_#{Faker::Commerce.department}" }
     sequence(:genre) {|n| "#{n}_#{Faker::Business.credit_card_type}" }
   end
 end

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -3,11 +3,11 @@
 # Table name: movies
 #
 #  id         :bigint           not null, primary key
-#  contents   :text
 #  desc       :text
 #  genre      :string
 #  position   :integer
 #  title      :text
+#  url        :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  text_id    :integer


### PR DESCRIPTION
## 目的

- 動画教材のURLを次の3パターンに対応させる
  1. 閲覧用の通常URL
  2. 共有で取得できるURL
  3. 「埋め込む」で取得できるiframeタグ

## 実装内容

- `movies` テーブルの `contents` カラムを `url` に変更
- url カラムを `"https://www.youtube.com/embed/<movie_id>` の形式に変換するマイグレーションファイルを作成
- 上記3パターンの場合に `"https://www.youtube.com/embed/<movie_id>`の形式に自動変換するように設定

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行
